### PR TITLE
Add RSS link to `<head>`

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
 	<meta charset="utf-8" />
 	<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 	<link rel="stylesheet" href="assets/css/main.css" />
+	<link rel="alternate" type="application/rss+xml" title="Future Turtles RSS Feed" href="https://us1.campaign-archive.com/feed?u=51ad6738951128de8653576d7&amp;id=2abe0abca0" />
 </head>
 
 <body class="is-preload">


### PR DESCRIPTION
# 🔧 Changes

Add an RSS link for the newsletter to `<head>` so RSS fans with auto-detect browser extensions and [Feedly](https://feedly.com) users will have an easier time finding it.